### PR TITLE
Fixed minor bugs in code.json file

### DIFF
--- a/code.json
+++ b/code.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "agency": "DOD",
     "measurementType": {
         "method": "other",
@@ -11,7 +11,7 @@
             "organization": "US Army Research Laboratory",
             "description": "ARL DCCSO provides a framework for (constrained) optimization of molecular properties over a combinatorial set of molecules. ",
             "tags": [
-                "policy"
+                "constrained optimization", "chemistry"
             ],
             "contact": {
                 "email": "berend.c.rinderspacher.civ@mail.mil",


### PR DESCRIPTION
I noticed two bugs in the code.json file.  First, the version number listed at the top should be 2.0.0 as it is the version of the JSON schema in use, **not** the version of the code itself; that is listed further below in the code.json file (see [here](https://code.gov/#/policy-guide/docs/compliance/inventory-code) for more info), and second the tags were incorrect.  You might need to update the tags with other, better ones; the tags are like the keyword index you might add when submitting a paper to a journal.